### PR TITLE
reAdded news back to translations.yml

### DIFF
--- a/src/site/_data/translations.yml
+++ b/src/site/_data/translations.yml
@@ -21,7 +21,7 @@ nav:
     resources: Resources
     meetings: Meetings
     members: Members
-    news:
+    news: News
     human-of-medicine: Humans of Medicine
     login: Login
     logout: Logout
@@ -39,7 +39,7 @@ nav:
     resources: Ressources
     meetings: Réunions
     members: Membres
-    news:
+    news: Nouvelles
     human-of-medicine: Humains de la Médecine
     login: Se connecter
     logout: Se déconnecter


### PR DESCRIPTION
HotFix for missing news from Navigation.
- Seems the news accidently got deleted from translations.yml. Causing the element to appear "not" on the page.