### PR TITLE
Enhancement - Fix to have Travis minify bundle.js to make bundle ~ 2 MB smaller

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ TARGET_BRANCH="master"
 function doCompile {
   #Renaming gemfile for build 
   mv Gemfile notGemfile
-  gulp build
+  gulp buildProd
   #renaming gemfile back after build completes to avoid errors
   mv notGemfile Gemfile
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gulp-postcss": "^6.2.0",
     "gulp-sass": "^2.3.2",
     "gulp-sourcemaps": "^1.9.1",
+    "gulp-uglify": "^3.0.0",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.11",
     "jasmine": "^2.8.0",


### PR DESCRIPTION
- Added new devDependency gulp-uglify.
- Added new gulp commands buildJekyllProduction, buildJsProduction.
- Added new function to gulp.js bundleProd
- Changed deploy.sh to call gulp buildProd instead of gulp build.

## Documentation
Added sepearate production values because compressing the bundle.js takes roughly 30 seconds longer than leaving it uncompressed. Therefore
- Use the normal gulp build, command when working with website locally.
- Travis will use the Production commands when building for production.
- Trade off is website will take ~ 30 seconds longer to build each time, however users should have a faster connection to the website.