### PR TITLE
Fix non zero day Security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jquery-bar-rating": "^1.2.2",
     "js-cookie": "^2.2.0",
     "json-style-converter": "^1.0.3",
-    "jsonwebtoken": "^8.0.0",
+    "jsonwebtoken": "^8.2.0",
     "page": "^1.7.1",
     "request-promise": "^4.2.2",
     "vex-dialog": "^1.0.6",


### PR DESCRIPTION
- Update Json webtoken package to fix high severity vulnerability **Uninitialized Memory Exposure**
- Issue caught through snyk

```
Affected versions of this package are vulnerable to Uninitialized Memory Exposure. An attacker could extract sensitive data from uninitialized memory or may cause a Denial of Service (DoS) by passing in a large number, in setups where typed user input can be passed (e.g. from JSON).
```